### PR TITLE
uthash master no longer matches the sha1 in this tap, this is a fix

### DIFF
--- a/uthash.rb
+++ b/uthash.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Uthash < Formula
   homepage 'http://troydhanson.github.io/uthash/'
-  url 'https://github.com/troydhanson/uthash/archive/master.zip'
-  sha1 '27bbfb08fb93cb339ce7b114e1d43909756f2355'
-  version 'Master'
+  url 'https://github.com/troydhanson/uthash/archive/58d5990617.zip'
+  sha1 '015622dfee4367b5de07a7207f7beb3768e0bd99'
+  version '58d5990617'
 
   def install
     include.install Dir['src/*']


### PR DESCRIPTION
Using a commit specific URL and version, with an updated sha1, so this will not break in the future (only become outdated)
